### PR TITLE
Laravel 5.5 Autoloader support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,12 @@
         "psr-4": {
             "Bader\\ClearOrdersBy\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Bader\\ClearOrdersBy\\clearOrdersByServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
As the title of the PR says, this just adds support for Laravel 5.5 auto finding/loading the package. 